### PR TITLE
fix(sec): upgrade io.springfox:springfox-swagger-ui to 2.10.0

### DIFF
--- a/xpay-code/pom.xml
+++ b/xpay-code/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
         <dependency>
             <groupId>io.springfox</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in io.springfox:springfox-swagger-ui 2.7.0
- [CVE-2019-17495](https://www.oscs1024.com/hd/CVE-2019-17495)


### What did I do？
Upgrade io.springfox:springfox-swagger-ui from 2.7.0 to 2.10.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS